### PR TITLE
Plugin.php ミスタイプ修正

### DIFF
--- a/docs/ja/plugin_quickstart_import.md
+++ b/docs/ja/plugin_quickstart_import.md
@@ -80,7 +80,7 @@ class Plugin extends PluginImportBase{
             if (!isset($product_version_code)) break;
             // 製品バージョンコードで、製品バージョンテーブルを読み込みます
             $product_version = getModelName('product_version')
-                ::where('value->product_version_code、, $product_version_code)->first();
+                ::where('value->product_version_code', $product_version_code)->first();
             // 製品バージョンテーブルが取得できなかった場合は次の行にスキップします
             if (!isset($product_version)) continue;
             // 明細行と製品バージョンテーブルから契約明細データを編集します


### PR DESCRIPTION
公式ドキュメント、プラグイン(インポート) のPlugin.phpソースにミスタイプが有り、あまりコードに明るくない方（コードハイライトのないエディタで編集する場合とくに）だと導入の妨げになるかと思いました。